### PR TITLE
Add npm test script and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# Projet CV
+
+Ce dépôt contient les fichiers HTML, SCSS et CSS d'un CV.
+
+## Scripts disponibles
+
+- `npm run sass` &ndash; compile les fichiers SCSS en surveillant les modifications.
+- `npm test` &ndash; compile les fichiers SCSS vers `css` sans générer de source map.
+
+Pour lancer le test :
+
+```bash
+npm test
+```
+

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "sass": "sass -w scss:css"
+    "sass": "sass -w scss:css",
+    "test": "sass scss:css --no-source-map"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- add `test` script for SASS
- document scripts in README

## Testing
- `npm test` *(fails: `sass` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684762d380388328867183fe487f5ea3