### PR TITLE
Remove redundant Google fonts preconnect

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <script src="https://kit.fontawesome.com/0ff922a1dc.js" crossorigin="anonymous"></script>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link
         href="https://fonts.googleapis.com/css2?family=Inconsolata:wdth,wght@300,400,700&family=Reddit+Sans&display=swap"


### PR DESCRIPTION
## Summary
- clean up duplicate link preconnect entry for Google fonts

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684764c082f4832893994ffebef27261