### PR TITLE
Fix coffee origin heading

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,7 +81,7 @@
                     <i class="fa-regular fa-star text-primary"></i>
                     <i class="fa-regular fa-star text-primary"></i>
                 </div>
-                <h3>ROUSSE</h3>
+                <h3>RUSSE</h3>
                 <div class="stars-container">
                     <i class="fa-solid fa-star text-primary"></i>
                     <i class="fa-solid fa-star text-primary"></i>


### PR DESCRIPTION
## Summary
- correct a typo in the coffee origin heading

## Testing
- `grep -n "RUSSE" -n index.html`


------
https://chatgpt.com/codex/tasks/task_e_684764c881688328b47a97e14a606640